### PR TITLE
Adaptive time stepping

### DIFF
--- a/Source/Evolve.cpp
+++ b/Source/Evolve.cpp
@@ -18,11 +18,15 @@ void Vidyut::Evolve()
 {
     Real cur_time = t_new[0];
     int last_plot_file_step = 0;
+    Real plottime = 0.0;
+    Real chktime = 0.0;
 
     //there is a slight issue when restart file is not a multiple
     //a plot file may get the same number with an "old" file generated
     int plotfilenum=amrex::Math::floor(amrex::Real(istep[0])/amrex::Real(plot_int));
     int chkfilenum=amrex::Math::floor(amrex::Real(istep[0])/amrex::Real(chk_int));
+    if(plot_time > 0.0) plotfilenum=amrex::Math::floor(amrex::Real(cur_time)/amrex::Real(plot_time));
+    if(chk_time > 0.0) chkfilenum=amrex::Math::floor(amrex::Real(cur_time)/amrex::Real(chk_time));
     amrex::Real dt_edrift,dt_ediff,dt_diel_relax;
     amrex::Real dt_edrift_lev,dt_ediff_lev,dt_diel_relax_lev;
 
@@ -57,7 +61,7 @@ void Vidyut::Evolve()
         amrex::Print()<<"global minimum electron drift, diffusion and dielectric relaxation time scales (sec):"<<
         dt_edrift<<"\t"<<dt_ediff<<"\t"<<dt_diel_relax<<"\n";
 
-        ComputeDt();
+        ComputeDt(cur_time, adaptive_dt_delay, dt_edrift, dt_ediff, dt_diel_relax);
 
         if (max_level > 0 && regrid_int > 0)  // We may need to regrid
         {
@@ -231,6 +235,8 @@ void Vidyut::Evolve()
         }
 
         cur_time += dt_common;
+        plottime += dt_common;
+        chktime += dt_common;
 
         amrex::Print() << "Coarse STEP " << step + 1 << " ends."
         << " TIME = " << cur_time << " DT = " << dt_common << std::endl;
@@ -241,14 +247,29 @@ void Vidyut::Evolve()
             t_new[lev] = cur_time;
         }
 
-        if (plot_int > 0 && (step + 1) % plot_int == 0)
+        if (plot_time > 0){
+            if(plottime > plot_time){
+                last_plot_file_step = step + 1;
+                plotfilenum++;
+                WritePlotFile(plotfilenum);
+                plottime = 0.0;
+            }
+        }
+        else if (plot_int > 0 && (step + 1) % plot_int == 0)
         {
             last_plot_file_step = step + 1;
             plotfilenum++;
             WritePlotFile(plotfilenum);
         }
 
-        if (chk_int > 0 && (step + 1) % chk_int == 0)
+        if(chk_time > 0){
+            if(chktime > chk_time){
+                chkfilenum++;
+                WriteCheckpointFile(chkfilenum);
+                chktime = 0.0;
+            }
+        }
+        else if (chk_int > 0 && (step + 1) % chk_int == 0)
         {
             chkfilenum++;
             WriteCheckpointFile(chkfilenum);

--- a/Source/HelperFuncs.H
+++ b/Source/HelperFuncs.H
@@ -38,9 +38,13 @@ amrex::Real get_efield_alongdir(int i,int j,int k,int dir,
         ip2[dir]+=2;
     
         //fdash = (-f_{i+2}+4f_{i+1}-3f_i)/(2 dx)
-        efield_dir=-0.5*(  -s_arr(ip2,POT_ID) 
+        if(domhi[dir] - domlo[dir] > 2){
+            efield_dir=-0.5*(  -s_arr(ip2,POT_ID) 
                       + 4.0*s_arr(ip1,POT_ID)
                       - 3.0*s_arr(cellid,POT_ID))/dx[dir];
+        } else {
+            efield_dir=-(s_arr(ip1,POT_ID) - s_arr(cellid,POT_ID))/dx[dir];
+        }
     }
     else if(cellid[dir]==domhi[dir])
     {
@@ -50,9 +54,13 @@ amrex::Real get_efield_alongdir(int i,int j,int k,int dir,
         im2[dir]-=2;
     
         //fdash = (f_{i-2}-4f_{i-1}+3f_i)/(2 dx)
-        efield_dir=-0.5*(     s_arr(im2,POT_ID)
+        if(domhi[dir] - domlo[dir] > 2){
+            efield_dir=-0.5*(     s_arr(im2,POT_ID)
                         - 4.0*s_arr(im1,POT_ID)
                         + 3.0*s_arr(cellid,POT_ID))/dx[dir];
+        } else {
+            efield_dir=-(s_arr(cellid,POT_ID) - s_arr(im1,POT_ID))/dx[dir];
+        }
     }
     else
     {

--- a/Source/Vidyut.H
+++ b/Source/Vidyut.H
@@ -166,9 +166,16 @@ public:
     amrex::Vector<int> neutral_bc_hi{ROBINBC, ROBINBC, ROBINBC};
     
     // advective cfl number - dt = cfl*dx/umax
-    amrex::Real cfl = 0.7;
+    amrex::Real advective_cfl = 0.7;
+    amrex::Real diffusive_cfl = 1.0;
+    amrex::Real dielectric_cfl = 1.0;
 
     amrex::Real fixed_dt=1e-12;
+    int adaptive_dt = 0;
+    amrex::Real dt_min=1e-14;
+    amrex::Real dt_max=1e-9;
+    amrex::Real adaptive_dt_delay = 0.0;
+    amrex::Real dt_stretch = std::numeric_limits<amrex::Real>::max();
 
     amrex::Real linsolve_reltol = 1e-10;
     amrex::Real linsolve_abstol = 1e-10;
@@ -237,10 +244,12 @@ public:
     // plotfile prefix and frequency
     std::string plot_file{"plt"};
     int plot_int = -1;
+    amrex::Real plot_time = -1.0;
 
     // checkpoint prefix and frequency
     std::string chk_file{"chk"};
     int chk_int = -1;
+    amrex::Real chk_time = -1.0;
 
     // Electron species index
     int E_IDX = 0;
@@ -274,7 +283,8 @@ private:
                  amrex::Vector<amrex::MultiFab*>& data, amrex::Vector<amrex::Real>& datatime);
 
     // a wrapper for EstTimeStep(0
-    void ComputeDt();
+    void ComputeDt(amrex::Real cur_time, amrex::Real dt_delay, amrex::Real dt_edrift, 
+                   amrex::Real dt_ediff, amrex::Real dt_diel_relax);
 
     // put together an array of multifabs for writing
     amrex::Vector<const amrex::MultiFab*> PlotFileMF() const;

--- a/Source/Vidyut.cpp
+++ b/Source/Vidyut.cpp
@@ -146,7 +146,7 @@ void Vidyut::InitData()
         InitFromScratch(time);
         AverageDown();
 
-        if (chk_int > 0)
+        if (chk_int > 0 || chk_time > 0.0)
         {
             WriteCheckpointFile(0);
         }
@@ -158,7 +158,7 @@ void Vidyut::InitData()
         ReadCheckpointFile();
     }
 
-    if (plot_int > 0)
+    if (plot_int > 0 || plot_time > 0.0)
     {
         WritePlotFile(amrex::Math::floor
                       (amrex::Real(istep[0])/amrex::Real(plot_int)));
@@ -271,8 +271,10 @@ void Vidyut::ReadParameters()
         pp.query("regrid_int", regrid_int);
         pp.query("plot_file", plot_file);
         pp.query("plot_int", plot_int);
+        pp.query("plot_time", plot_time);
         pp.query("chk_file", chk_file);
         pp.query("chk_int", chk_int);
+        pp.query("chk_time", chk_time);
         pp.query("restart", restart_chkfile);
     }
 
@@ -280,6 +282,16 @@ void Vidyut::ReadParameters()
         ParmParse pp("vidyut");
 
         pp.query("dt", fixed_dt);
+        pp.query("adaptive_dt", adaptive_dt);
+        if(adaptive_dt){
+            pp.query("advective_cfl", advective_cfl);
+            pp.query("diffusive_cfl", diffusive_cfl);
+            pp.query("dielectric_cfl", dielectric_cfl);
+            pp.query("dt_min", dt_min);
+            pp.query("dt_max", dt_max);
+            pp.query("adaptive_dt_delay", adaptive_dt_delay);
+            pp.query("dt_stretch", dt_stretch);
+        }
         pp.query("use_hypre",use_hypre);
 
         pp.query("linsolve_reltol",linsolve_reltol);


### PR DESCRIPTION
- Added option for adaptive time stepping based on advective and diffusive cfl restraints, and dielectric relaxation time. Modifications include a user-defined time delay for switching from constant to adaptive time stepping at a specified time, a stretch factor to limit dt increase between time steps, and min/max dt for adaptive time stepping.

- Modified the efield helper function to use 1st order one-sided derivatives when a small domain is used.

- Added option to specify restart and plot file time intervals in place of using step number intervals. When a plot or check time is specified, it overwrites any plot or check ints in the input file.